### PR TITLE
proton: set per-game shader caches when shader pre-caching is disabled

### DIFF
--- a/proton
+++ b/proton
@@ -1414,6 +1414,8 @@ def default_compat_config():
                 ]:
             ret.add("hideapu")
 
+    if "STEAM_COMPAT_SHADER_PATH" in os.environ:
+        ret.add("localshadercache")
     #options to also be enabled for prerequisite setup steps
     if "STEAM_COMPAT_APP_ID" in os.environ:
         appid = os.environ["STEAM_COMPAT_APP_ID"]
@@ -1599,6 +1601,48 @@ class Session:
         self.log_file = open(lfile_path, "a")
         return True
 
+    def setup_local_shader_cache(self):
+        path = os.environ.get("STEAM_COMPAT_SHADER_PATH", "")
+        if not path:
+            return
+        shader_cache_name = "steamapp_shader_cache"
+        shader_cache_vars = {
+            # Nvidia
+            "__GL_SHADER_DISK_CACHE_APP_NAME": shader_cache_name,
+            "__GL_SHADER_DISK_CACHE_PATH": os.path.join(path, "nvidiav1"),
+            "__GL_SHADER_DISK_CACHE_READ_ONLY_APP_NAME": "steam_shader_cache;steamapp_merged_shader_cache",
+            "__GL_SHADER_DISK_CACHE_SIZE": "5000000000",
+            #"__GL_SHADER_DISK_CACHE_SKIP_CLEANUP": "1",
+            # Mesa
+            "MESA_DISK_CACHE_READ_ONLY_FOZ_DBS": "steam_cache,steam_precompiled",
+            "MESA_DISK_CACHE_SINGLE_FILE": "1",
+            "MESA_GLSL_CACHE_DIR": path,
+            "MESA_GLSL_CACHE_MAX_SIZE": "5G",
+            "MESA_SHADER_CACHE_DIR": path,
+            "MESA_SHADER_CACHE_MAX_SIZE": "5G",
+            # AMD VK
+            "AMD_VK_PIPELINE_CACHE_FILENAME": shader_cache_name,
+            "AMD_VK_PIPELINE_CACHE_PATH": os.path.join(path, "AMDv1"),
+            "AMD_VK_USE_PIPELINE_CACHE": "1",
+            # DXVK
+            "DXVK_STATE_CACHE_PATH": os.path.join(path, "DXVK_state_cache"),
+            # VKD3D
+            "VKD3D_SHADER_CACHE_PATH": os.path.join(path, "VKD3D_shader_cache")
+        }
+        for var, val in shader_cache_vars.items():
+            if var in os.environ:
+                continue
+            if var in {
+                "__GL_SHADER_DISK_CACHE_PATH",
+                "MESA_GLSL_CACHE_DIR",
+                "MESA_SHADER_CACHE_DIR",
+                "AMD_VK_PIPELINE_CACHE_PATH",
+                "DXVK_STATE_CACHE_PATH",
+                "VKD3D_SHADER_CACHE_PATH",
+            }:
+                makedirs(val)
+            self.env[var] = val
+
     def init_session(self, update_prefix_files):
         self.env["WINEPREFIX"] = g_compatdata.prefix_dir
 
@@ -1669,6 +1713,7 @@ class Session:
         self.check_environment("PROTON_NATIVE_AGS", "nativeags")
         self.check_environment("PROTON_ENABLE_HDR", "hdr")
         self.check_environment("PROTON_NO_NTSYNC", "nontsync")
+        self.check_environment("PROTON_LOCAL_SHADER_CACHE", "localshadercache")
 
         if "PROTON_ADD_CONFIG" in self.env:
             for c in proton_config:
@@ -1697,6 +1742,9 @@ class Session:
             self.env["MESA_EXTENSION_MAX_YEAR"] = "2003"
             #nvidia override
             self.env["__GL_ExtensionStringVersion"] = "17700"
+
+        if "localshadercache" in self.compat_config:
+            self.setup_local_shader_cache()
 
         if os.environ.get("SteamGameId", 0) in [
                 "661920", #Claybook


### PR DESCRIPTION
Steam only uses per-game shader caches when shader pre-caching is enabled, otherwise it leaves it up to the driver and system configuration.

In case the related env variables are missing from the environment (i.e. pre-caching is disabled), set them to some sane defaults to isolate caches between games. The paths depend on `STEAM_COMPAT_SHADER_PATH` being set and is enabled by default. Disable using `PROTON_LOCAL_SHADER_CACHE=0`.