### PR TITLE
make: add distclean targets

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1477,6 +1477,11 @@ $(DIST_FONTS): fonts
 
 all-dist: $(DIST_FONTS)
 
+fonts-distclean::
+	rm -rf $(FONTS_OBJ)
+
+distclean: fonts-distclean
+
 
 ##
 ## Gecko
@@ -1511,6 +1516,11 @@ $(OBJ)/.gecko-x86_64-dist: $(SRC)/contrib/$(GECKO_x86_64_TARBALL)
 
 all-dist: $(OBJ)/.gecko-i386-dist $(OBJ)/.gecko-x86_64-dist
 
+gecko-distclean::
+	rm -rf $(OBJ)/.gecko-{i386,x86_64}-dist
+
+distclean: gecko-distclean
+
 
 ##
 ## wine-mono
@@ -1534,6 +1544,11 @@ $(DIST_WINEMONO): $(SRC)/contrib/$(WINEMONO_TARBALL)
 	touch $@
 
 all-dist: $(DIST_WINEMONO)
+
+mono-distclean::
+	rm -rf $(OBJ)/.wine-mono-dist
+
+distclean: mono-distclean
 
 
 ##
@@ -1561,6 +1576,10 @@ $(DIST_XALIA): $(SRC)/contrib/$(XALIA_ZIP) $(SRC)/xalia-fixups.gudl
 
 all-dist: $(DIST_XALIA)
 
+xalia-distclean::
+	rm -rf $(OBJ)/.xalia-dist
+
+distclean: xalia-distclean
 
 ##
 ## ICU
@@ -1598,6 +1617,10 @@ ifneq ($(findstring aarch64,$(unix_ARCHS)),)
 all-dist: $(OBJ)/.icu-aarch64-dist
 endif
 
+icu-distclean::
+	rm -rf $(OBJ)/.icu-{x86_64,i386}-dist
+
+distclean: icu-distclean
 
 ##
 ## X11 locale
@@ -1792,6 +1815,18 @@ redist: all
 	XZ_OPT="-9 -T$(J)" tar -cJf $(BUILD_NAME).tar.xz $(BUILD_NAME)
 	sha512sum $(BUILD_NAME).tar.xz > $(BUILD_NAME).sha512sum
 	@echo "Proton build available at $(BUILD_NAME).tar.xz"
+
+
+##
+## make distclean
+##
+
+dist-distclean::
+	rm -rf $(OBJ)/wine
+	rm -rf $(OBJ)/dist
+	rm -rf $(OBJ)/compile_commands
+
+distclean: dist-distclean
 
 
 ##

--- a/make/rules-common.mk
+++ b/make/rules-common.mk
@@ -171,6 +171,12 @@ $(2)_$(3)_ENV += \
 endif
 
 endif
+$(1)-$(3)-distclean::
+	rm -rf $$($(2)_$(3)_OBJ)
+	rm -rf $$($(2)_$(3)_DST)
+	rm  -f $$(OBJ)/.$(1)-$(3)-{configure,build,post-build,dist}
+
+distclean: $(1)-$(3)-distclean
 endef
 
 ifneq ($(UNSTRIPPED_BUILD),)

--- a/make/rules-source.mk
+++ b/make/rules-source.mk
@@ -43,6 +43,7 @@ all: all-source
 $(1)-clean::
 $(1)-distclean::
 	rm -rf $$($(2)_SRC)
+	rm  -f $$(OBJ)/.$(1)-{source,post-source}
 
 clean: $(1)-clean
 distclean: $(1)-distclean

--- a/make/rules-wine-requests.mk
+++ b/make/rules-wine-requests.mk
@@ -38,6 +38,11 @@ $$(OBJ)/.$(1)-wine-requests: | $$(OBJ)/.$(1)-post-source
 $$(OBJ)/.$(1)-i386-build: $$(OBJ)/.$(1)-wine-requests
 $$(OBJ)/.$(1)-x86_64-build: $$(OBJ)/.$(1)-wine-requests
 $$(OBJ)/.$(1)-aarch64-build: $$(OBJ)/.$(1)-wine-requests
+
+$(1)-requests-distclean::
+	rm -rf $$(OBJ)/.$(1)-wine-requests
+
+distclean: $(1)-requests-distclean
 endef
 
 rules-wine-requests = $(call create-rules-wine-requests,$(1),$(call toupper,$(1)))

--- a/make/rules-wine-tools.mk
+++ b/make/rules-wine-tools.mk
@@ -27,6 +27,10 @@ endif
 
 $$(OBJ)/.$(1)-$(3)-build: $$(OBJ)/.$(1)-$(3)-tools
 
+$(1)-$(3)-tools-distclean::
+	rm -rf $$(OBJ)/.$(1)-$(3)-tools
+
+distclean: $(1)-$(3)-tools-distclean
 endif
 endef
 


### PR DESCRIPTION
Adds a few make targets for cleaning the build directory. For example
* `make distclean` will clean everything except the `Makefile`
* `make dxvk-distclean` will remove the source copy with the tracking files `.dxvk-source`, `.dxvk-post-source`
* `make dxvk-x86_64-distclean` will remove the obj-x86_64 and dst-x86_64 directories for dxvk and the `.dxvk-x86_64-{configure,build,post-build,dist}` tracking files
* `make dxvk-i386-distclean` is the same as the above for `i386`